### PR TITLE
Add tests for near-lossless and fix thumbnailer.cc

### DIFF
--- a/src/thumbnailer.cc
+++ b/src/thumbnailer.cc
@@ -314,7 +314,10 @@ Thumbnailer::Status Thumbnailer::GenerateAnimationEqualPSNR(
 }
 
 Thumbnailer::Status Thumbnailer::TryNearLossless(WebPData* const webp_data) {
-  int anim_size = webp_data->size;
+  int anim_size = 0;
+  for (auto& frame : frames_) {
+    anim_size += frame.encoded_size;
+  }
 
   WebPAnimEncoderDelete(enc_);
   enc_ = WebPAnimEncoderNew(frames_[0].pic.width, frames_[0].pic.height,

--- a/src/thumbnailer.cc
+++ b/src/thumbnailer.cc
@@ -314,6 +314,8 @@ Thumbnailer::Status Thumbnailer::GenerateAnimationEqualPSNR(
 }
 
 Thumbnailer::Status Thumbnailer::TryNearLossless(WebPData* const webp_data) {
+  // The webp_data->size is not used here instead since it is higher than the
+  // sum of encoded-frame sizes.
   int anim_size = 0;
   for (auto& frame : frames_) {
     anim_size += frame.encoded_size;

--- a/test/thumbnailer_test.cc
+++ b/test/thumbnailer_test.cc
@@ -103,14 +103,16 @@ class WebPTestGenerator {
   }
 };
 
-class GenerateAnimationTest
-    : public ::testing::TestWithParam<std::tuple<int, uint8_t, bool, bool>> {};
+class GenerateAnimationTest : public ::testing::TestWithParam<
+                                  std::tuple<int, uint8_t, bool, bool, bool>> {
+};
 
 TEST_P(GenerateAnimationTest, IsGenerated) {
   const int pic_count = std::get<0>(GetParam());
   const uint8_t transparency = std::get<1>(GetParam());
   const bool use_randomized = std::get<2>(GetParam());
   const bool equal_psnr = std::get<3>(GetParam());
+  const bool try_near_lossless = std::get<4>(GetParam());
 
   libwebp::Thumbnailer thumbnailer = libwebp::Thumbnailer();
   auto pics =
@@ -130,6 +132,12 @@ TEST_P(GenerateAnimationTest, IsGenerated) {
     ASSERT_EQ(thumbnailer.GenerateAnimation(webp_data.get()),
               libwebp::Thumbnailer::kOk);
   }
+
+  if (try_near_lossless) {
+    ASSERT_EQ(thumbnailer.TryNearLossless(webp_data.get()),
+              libwebp::Thumbnailer::kOk);
+  }
+
   EXPECT_LE(webp_data->size, kDefaultBudget);
   EXPECT_GT(webp_data->size, 0);
 }
@@ -137,6 +145,7 @@ TEST_P(GenerateAnimationTest, IsGenerated) {
 INSTANTIATE_TEST_CASE_P(ThumbnailerTest, GenerateAnimationTest,
                         ::testing::Combine(::testing::Values(10),
                                            ::testing::Values(0xff, 0xaf),
+                                           ::testing::Values(false, true),
                                            ::testing::Values(false, true),
                                            ::testing::Values(false, true)));
 


### PR DESCRIPTION
- Add tests for `TryNearLossless()`.
- Replace animation size in `TryNearLossless()` with the sum of encoded-frame sizes.