### PR TITLE
Reduce WebPEncode() calls.

### DIFF
--- a/src/thumbnailer.cc
+++ b/src/thumbnailer.cc
@@ -58,11 +58,11 @@ Thumbnailer::Status Thumbnailer::AddFrame(const WebPPicture& pic,
 
 Thumbnailer::Status Thumbnailer::GetPictureStats(int ind, int* const pic_size,
                                                  float* const pic_PSNR) {
-  int quality = int(frames_[ind].config.quality);
-  if (!frames_[ind].config.near_lossless &&
+  const int quality = int(frames_[ind].config.quality);
+  if (!frames_[ind].config.lossless &&
       frames_[ind].lossy_data[quality].first != -1) {
-    *pic_size = frames_[ind].lossy_data->first;
-    *pic_PSNR = frames_[ind].lossy_data->second;
+    *pic_size = frames_[ind].lossy_data[quality].first;
+    *pic_PSNR = frames_[ind].lossy_data[quality].second;
     return kOk;
   }
 
@@ -90,6 +90,9 @@ Thumbnailer::Status Thumbnailer::GetPictureStats(int ind, int* const pic_size,
     *pic_PSNR = distortion_result[4];  // PSNR-all.
   }
 
+  if (!frames_[ind].config.lossless) {
+    frames_[ind].lossy_data[quality] = std::make_pair(*pic_size, *pic_PSNR);
+  }
   WebPPictureFree(&new_pic);
 
   return kOk;
@@ -155,7 +158,7 @@ Thumbnailer::Status Thumbnailer::GenerateAnimation(WebPData* const webp_data) {
             });
 
   for (auto& frame : frames_) {
-    // Initialize `lossy_data` array.
+    // Initialize 'lossy_data' array.
     std::fill(frame.lossy_data, frame.lossy_data + 101,
               std::make_pair(-1, -1.0));
   }

--- a/src/thumbnailer.cc
+++ b/src/thumbnailer.cc
@@ -284,7 +284,7 @@ Thumbnailer::Status Thumbnailer::GenerateAnimationEqualPSNR(
       WebPPictureFree(&new_pic);
 
       std::cerr << frame.config.quality << ' ';
-      curr_ind++;
+      ++curr_ind;
     }
 
     // Add last frame.
@@ -402,7 +402,7 @@ Thumbnailer::Status Thumbnailer::TryNearLossless(WebPData* const webp_data) {
       return kMemoryError;
     }
     WebPPictureFree(&new_pic);
-    curr_ind++;
+    ++curr_ind;
   }
 
   std::cerr << std::endl;

--- a/src/thumbnailer.h
+++ b/src/thumbnailer.h
@@ -99,6 +99,7 @@ class Thumbnailer {
     int final_quality = -1;
     float final_psnr;
     bool near_lossless = false;
+    std::pair<int, float> lossy_data[101];
   };
   std::vector<FrameData> frames_;
   WebPAnimEncoder* enc_ = NULL;
@@ -107,11 +108,9 @@ class Thumbnailer {
   int byte_budget_;
   int minimum_lossy_quality_;
 
-  // Compute the size (in bytes) and PSNR of a re-encoded WebPPicture at given
-  // config. The resulting size and PSNR will be stored in '*pic_size' and
-  // '*pic_PSNR' respectively.
-  Status GetPictureStats(const WebPPicture& pic, const WebPConfig& config,
-                         int* const pic_size, float* const pic_PSNR);
+  // Compute the size (in bytes) and PSNR of the 'ind'-th frame. The resulting
+  // size and PSNR will be stored in '*pic_size' and '*pic_PSNR' respectively.
+  Status GetPictureStats(int ind, int* const pic_size, float* const pic_PSNR);
 
   Status SetLoopCount(WebPData* const webp_data);
 

--- a/src/thumbnailer.h
+++ b/src/thumbnailer.h
@@ -99,7 +99,11 @@ class Thumbnailer {
     int final_quality = -1;
     float final_psnr;
     bool near_lossless = false;
-    std::pair<int, float> lossy_data[101];
+    std::pair<int, float>
+        lossy_data[101];  // Array containing pairs of (size, psnr) for
+                          // qualities in range [0..100] when using lossy
+                          // encoding. If WebPEncode() has not been called for
+                          // quality 'x', lossy_data['x'] = (-1,-1.0).
   };
   std::vector<FrameData> frames_;
   WebPAnimEncoder* enc_ = NULL;

--- a/src/thumbnailer.h
+++ b/src/thumbnailer.h
@@ -99,11 +99,10 @@ class Thumbnailer {
     int final_quality = -1;
     float final_psnr;
     bool near_lossless = false;
-    std::pair<int, float>
-        lossy_data[101];  // Array containing pairs of (size, psnr) for
-                          // qualities in range [0..100] when using lossy
-                          // encoding. If WebPEncode() has not been called for
-                          // quality 'x', lossy_data['x'] = (-1,-1.0).
+    // Array containing pairs of (size, psnr) for qualities in range [0..100]
+    // when using lossy encoding. If WebPEncode() has not been called for
+    // quality 'x', lossy_data['x'] = (-1,-1.0).
+    std::pair<int, float> lossy_data[101];
   };
   std::vector<FrameData> frames_;
   WebPAnimEncoder* enc_ = NULL;
@@ -112,7 +111,7 @@ class Thumbnailer {
   int byte_budget_;
   int minimum_lossy_quality_;
 
-  // Compute the size (in bytes) and PSNR of the 'ind'-th frame. The resulting
+  // Computes the size (in bytes) and PSNR of the 'ind'-th frame. The resulting
   // size and PSNR will be stored in '*pic_size' and '*pic_PSNR' respectively.
   Status GetPictureStats(int ind, int* const pic_size, float* const pic_PSNR);
 

--- a/src/thumbnailer_slope_optim.cc
+++ b/src/thumbnailer_slope_optim.cc
@@ -19,7 +19,7 @@ namespace libwebp {
 Thumbnailer::Status Thumbnailer::GenerateAnimationSlopeOptim(
     WebPData* const webp_data) {
   for (auto& frame : frames_) {
-    // Initialize `lossy_data` array.
+    // Initialize 'lossy_data' array.
     std::fill(frame.lossy_data, frame.lossy_data + 101,
               std::make_pair(-1, -1.0));
   }

--- a/src/thumbnailer_slope_optim.cc
+++ b/src/thumbnailer_slope_optim.cc
@@ -73,7 +73,7 @@ Thumbnailer::Status Thumbnailer::FindMedianSlope(float* const median_slope) {
 
     slopes.push_back(pic_final_slope);
 
-    curr_ind++;
+    ++curr_ind;
   }
 
   std::sort(slopes.begin(), slopes.end());
@@ -118,7 +118,7 @@ Thumbnailer::Status Thumbnailer::LossyEncodeSlopeOptim(
 
   std::vector<int> optim_list;  // Vector of frames needed to find the quality
                                 // in the next binary search loop.
-  for (int i = 0; i < frames_.size(); i++) {
+  for (int i = 0; i < frames_.size(); ++i) {
     optim_list.push_back(i);
   }
 
@@ -228,7 +228,7 @@ Thumbnailer::Status Thumbnailer::LossyEncodeNoSlopeOptim(
     }
 
     num_remaining_frames--;
-    curr_ind++;
+    ++curr_ind;
   }
 
   for (auto& frame : frames_) {


### PR DESCRIPTION
- Add an array of pair (size, psnr) for each frame to store encoded sizes and psnr when call WebPEncode() for different quality values.
- Avoid call WebPEncode() for the same quality several times.