### PR TITLE
Add options to thumbnailer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(imagedec STATIC ${CMAKE_CURRENT_SOURCE_DIR}/imageio/image_dec.c
                             ${CMAKE_CURRENT_SOURCE_DIR}/imageio/tiffdec.c
                             ${CMAKE_CURRENT_SOURCE_DIR}/imageio/webpdec.c
                             ${CMAKE_CURRENT_SOURCE_DIR}/imageio/wicdec.c)
+
 # Find the standard image libraries.
 set(TB_DEP_IMG_LIBRARIES)
 foreach(I_LIB PNG JPEG TIFF)
@@ -32,8 +33,14 @@ foreach(I_LIB PNG JPEG TIFF)
 endforeach()
 message(STATUS "Adding ${TB_DEP_IMG_LIBRARIES} libraries.")
 
+# Example util
+add_library(example_util STATIC ${CMAKE_CURRENT_SOURCE_DIR}/examples/example_util.c)
+target_link_libraries(example_util webp imageio_util)
+target_include_directories(example_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 target_link_libraries(imagedec
                       imageio_util
+                      example_util
                       webpmux
                       webpdemux
                       webp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ add_library(imagedec STATIC ${CMAKE_CURRENT_SOURCE_DIR}/imageio/image_dec.c
                             ${CMAKE_CURRENT_SOURCE_DIR}/imageio/tiffdec.c
                             ${CMAKE_CURRENT_SOURCE_DIR}/imageio/webpdec.c
                             ${CMAKE_CURRENT_SOURCE_DIR}/imageio/wicdec.c)
-
 # Find the standard image libraries.
 set(TB_DEP_IMG_LIBRARIES)
 foreach(I_LIB PNG JPEG TIFF)
@@ -33,10 +32,10 @@ foreach(I_LIB PNG JPEG TIFF)
 endforeach()
 message(STATUS "Adding ${TB_DEP_IMG_LIBRARIES} libraries.")
 
+
 # Example util
 add_library(example_util STATIC ${CMAKE_CURRENT_SOURCE_DIR}/examples/example_util.c)
-target_link_libraries(example_util webp imageio_util)
-target_include_directories(example_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(example_util webp)
 
 target_link_libraries(imagedec
                       imageio_util

--- a/examples/example_util.c
+++ b/examples/example_util.c
@@ -1,0 +1,135 @@
+// Copyright 2012 Google Inc. All Rights Reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the COPYING file in the root of the source
+// tree. An additional intellectual property rights grant can be found
+// in the file PATENTS. All contributing project authors may
+// be found in the AUTHORS file in the root of the source tree.
+// -----------------------------------------------------------------------------
+//
+//  Utility functions used by the example programs.
+//
+
+#include "./example_util.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "webp/mux_types.h"
+#include "../imageio/imageio_util.h"
+
+//------------------------------------------------------------------------------
+// String parsing
+
+uint32_t ExUtilGetUInt(const char* const v, int base, int* const error) {
+  char* end = NULL;
+  const uint32_t n = (v != NULL) ? (uint32_t)strtoul(v, &end, base) : 0u;
+  if (end == v && error != NULL && !*error) {
+    *error = 1;
+    fprintf(stderr, "Error! '%s' is not an integer.\n",
+            (v != NULL) ? v : "(null)");
+  }
+  return n;
+}
+
+int ExUtilGetInt(const char* const v, int base, int* const error) {
+  return (int)ExUtilGetUInt(v, base, error);
+}
+
+int ExUtilGetInts(const char* v, int base, int max_output, int output[]) {
+  int n, error = 0;
+  for (n = 0; v != NULL && n < max_output; ++n) {
+    const int value = ExUtilGetInt(v, base, &error);
+    if (error) return -1;
+    output[n] = value;
+    v = strchr(v, ',');
+    if (v != NULL) ++v;   // skip over the trailing ','
+  }
+  return n;
+}
+
+float ExUtilGetFloat(const char* const v, int* const error) {
+  char* end = NULL;
+  const float f = (v != NULL) ? (float)strtod(v, &end) : 0.f;
+  if (end == v && error != NULL && !*error) {
+    *error = 1;
+    fprintf(stderr, "Error! '%s' is not a floating point number.\n",
+            (v != NULL) ? v : "(null)");
+  }
+  return f;
+}
+
+//------------------------------------------------------------------------------
+
+static void ResetCommandLineArguments(int argc, const char* argv[],
+                                      CommandLineArguments* const args) {
+  assert(args != NULL);
+  args->argc_ = argc;
+  args->argv_ = argv;
+  args->own_argv_ = 0;
+  WebPDataInit(&args->argv_data_);
+}
+
+void ExUtilDeleteCommandLineArguments(CommandLineArguments* const args) {
+  if (args != NULL) {
+    if (args->own_argv_) {
+      WebPFree((void*)args->argv_);
+      WebPDataClear(&args->argv_data_);
+    }
+    ResetCommandLineArguments(0, NULL, args);
+  }
+}
+
+#define MAX_ARGC 16384
+int ExUtilInitCommandLineArguments(int argc, const char* argv[],
+                                   CommandLineArguments* const args) {
+  if (args == NULL || argv == NULL) return 0;
+  ResetCommandLineArguments(argc, argv, args);
+  if (argc == 1 && argv[0][0] != '-') {
+    char* cur;
+    const char sep[] = " \t\r\n\f\v";
+
+#if defined(_WIN32) && defined(_UNICODE)
+    fprintf(stderr,
+            "Error: Reading arguments from a file is a feature unavailable "
+            "with Unicode binaries.\n");
+    return 0;
+#endif
+
+    if (!ExUtilReadFileToWebPData(argv[0], &args->argv_data_)) {
+      return 0;
+    }
+    args->own_argv_ = 1;
+    args->argv_ = (const char**)WebPMalloc(MAX_ARGC * sizeof(*args->argv_));
+    if (args->argv_ == NULL) return 0;
+
+    argc = 0;
+    for (cur = strtok((char*)args->argv_data_.bytes, sep);
+         cur != NULL;
+         cur = strtok(NULL, sep)) {
+      if (argc == MAX_ARGC) {
+        fprintf(stderr, "ERROR: Arguments limit %d reached\n", MAX_ARGC);
+        return 0;
+      }
+      assert(strlen(cur) != 0);
+      args->argv_[argc++] = cur;
+    }
+    args->argc_ = argc;
+  }
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+
+int ExUtilReadFileToWebPData(const char* const filename,
+                             WebPData* const webp_data) {
+  const uint8_t* data;
+  size_t size;
+  if (webp_data == NULL) return 0;
+  if (!ImgIoUtilReadFile(filename, &data, &size)) return 0;
+  webp_data->bytes = data;
+  webp_data->size = size;
+  return 1;
+}

--- a/examples/example_util.c
+++ b/examples/example_util.c
@@ -17,8 +17,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "webp/mux_types.h"
 #include "../imageio/imageio_util.h"
+#include "webp/mux_types.h"
 
 //------------------------------------------------------------------------------
 // String parsing
@@ -45,7 +45,7 @@ int ExUtilGetInts(const char* v, int base, int max_output, int output[]) {
     if (error) return -1;
     output[n] = value;
     v = strchr(v, ',');
-    if (v != NULL) ++v;   // skip over the trailing ','
+    if (v != NULL) ++v;  // skip over the trailing ','
   }
   return n;
 }
@@ -75,7 +75,7 @@ static void ResetCommandLineArguments(int argc, const char* argv[],
 void ExUtilDeleteCommandLineArguments(CommandLineArguments* const args) {
   if (args != NULL) {
     if (args->own_argv_) {
-      WebPFree((void*)args->argv_);
+      free((void*)args->argv_);
       WebPDataClear(&args->argv_data_);
     }
     ResetCommandLineArguments(0, NULL, args);
@@ -102,12 +102,11 @@ int ExUtilInitCommandLineArguments(int argc, const char* argv[],
       return 0;
     }
     args->own_argv_ = 1;
-    args->argv_ = (const char**)WebPMalloc(MAX_ARGC * sizeof(*args->argv_));
+    args->argv_ = (const char**)malloc(MAX_ARGC * sizeof(*args->argv_));
     if (args->argv_ == NULL) return 0;
 
     argc = 0;
-    for (cur = strtok((char*)args->argv_data_.bytes, sep);
-         cur != NULL;
+    for (cur = strtok((char*)args->argv_data_.bytes, sep); cur != NULL;
          cur = strtok(NULL, sep)) {
       if (argc == MAX_ARGC) {
         fprintf(stderr, "ERROR: Arguments limit %d reached\n", MAX_ARGC);

--- a/examples/example_util.h
+++ b/examples/example_util.h
@@ -1,0 +1,70 @@
+// Copyright 2012 Google Inc. All Rights Reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the COPYING file in the root of the source
+// tree. An additional intellectual property rights grant can be found
+// in the file PATENTS. All contributing project authors may
+// be found in the AUTHORS file in the root of the source tree.
+// -----------------------------------------------------------------------------
+//
+//  Utility functions used by the example programs.
+//
+
+#ifndef WEBP_EXAMPLES_EXAMPLE_UTIL_H_
+#define WEBP_EXAMPLES_EXAMPLE_UTIL_H_
+
+#include "webp/types.h"
+#include "webp/mux_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//------------------------------------------------------------------------------
+// String parsing
+
+// Parses 'v' using strto(ul|l|d)(). If error is non-NULL, '*error' is set to
+// true on failure while on success it is left unmodified to allow chaining of
+// calls. An error is only printed on the first occurrence.
+uint32_t ExUtilGetUInt(const char* const v, int base, int* const error);
+int ExUtilGetInt(const char* const v, int base, int* const error);
+float ExUtilGetFloat(const char* const v, int* const error);
+
+// This variant of ExUtilGetInt() will parse multiple integers from a
+// comma-separated list. Up to 'max_output' integers are parsed.
+// The result is placed in the output[] array, and the number of integers
+// actually parsed is returned, or -1 if an error occurred.
+int ExUtilGetInts(const char* v, int base, int max_output, int output[]);
+
+// Reads a file named 'filename' into a WebPData structure. The content of
+// webp_data is overwritten. Returns false in case of error.
+int ExUtilReadFileToWebPData(const char* const filename,
+                             WebPData* const webp_data);
+
+//------------------------------------------------------------------------------
+// Command-line arguments
+
+typedef struct {
+  int argc_;
+  const char** argv_;
+  WebPData argv_data_;
+  int own_argv_;
+} CommandLineArguments;
+
+// Initializes the structure from the command-line parameters. If there is
+// only one parameter and it does not start with a '-', then it is assumed to
+// be a file name. This file will be read and tokenized into command-line
+// arguments. The content of 'args' is overwritten.
+// Returns false in case of error (memory allocation failure, non
+// existing file, too many arguments, ...).
+int ExUtilInitCommandLineArguments(int argc, const char* argv[],
+                                   CommandLineArguments* const args);
+
+// Deallocate all memory and reset 'args'.
+void ExUtilDeleteCommandLineArguments(CommandLineArguments* const args);
+
+#ifdef __cplusplus
+}    // extern "C"
+#endif
+
+#endif  // WEBP_EXAMPLES_EXAMPLE_UTIL_H_

--- a/src/main.cc
+++ b/src/main.cc
@@ -65,7 +65,12 @@ int main(int argc, char* argv[]) {
       // and 'try_near_lossless'.
       slope_optim = true;
     } else if (!strcmp(argv[c], "-m")) {
+      // Effort/speed trade-off (0=fast, 6=slower-better), default value 4.
       thumbnailer_option.set_method(ExUtilGetInt(argv[++c], 0, &parse_error));
+    } else if (!strcmp(argv[c], "-slope_dpsnr")) {
+      // Maximum PSNR change used in slope optimization, default value 1.0.
+      thumbnailer_option.set_slope_dpsnr(
+          ExUtilGetFloat(argv[++c], &parse_error));
     }
   }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <string>
 
+#include "../examples/example_util.h"
 #include "thumbnailer.h"
 #include "thumbnailer.pb.h"
 
@@ -46,7 +47,7 @@ int main(int argc, char* argv[]) {
     if (!strcmp(argv[c], "-verbose")) {
       thumbnailer_option.set_verbose(true);
     }
-
+    int parse_error = 0;
     // Parsing generating method.
     if (!strcmp(argv[c], "-equal_psnr")) {
       // Generate animation so that all frames have the same PSNR.
@@ -63,6 +64,8 @@ int main(int argc, char* argv[]) {
       // Generate animation with slope optimization, ignore 'try_equal_psnr'
       // and 'try_near_lossless'.
       slope_optim = true;
+    } else if (!strcmp(argv[c], "-m")) {
+      thumbnailer_option.set_method(ExUtilGetInt(argv[++c], 0, &parse_error));
     }
   }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -72,6 +72,10 @@ int main(int argc, char* argv[]) {
       thumbnailer_option.set_slope_dpsnr(
           ExUtilGetFloat(argv[++c], &parse_error));
     }
+    if (parse_error) {
+      std::cerr << "Error parsing options." << std::endl;
+      return 1;
+    }
   }
 
   libwebp::Thumbnailer thumbnailer = libwebp::Thumbnailer(thumbnailer_option);

--- a/src/thumbnailer.h
+++ b/src/thumbnailer.h
@@ -128,6 +128,8 @@ class Thumbnailer {
   int byte_budget_;
   int minimum_lossy_quality_;
   bool verbose_;
+  int method_;
+  float slope_dPSNR_;
 
   // Computes the size (in bytes) and PSNR of the 'ind'-th frame. The resulting
   // size and PSNR will be stored in '*pic_size' and '*pic_PSNR' respectively.

--- a/src/thumbnailer.proto
+++ b/src/thumbnailer.proto
@@ -33,8 +33,9 @@ message ThumbnailerOption {
   // If true, thumbnailer will print various encoding statistics.
   optional bool verbose = 8 [default = false];
 
-  // effort/speed trade-off (0=fast, 6=slower-better)
+  // Effort/speed trade-off (0=fast, 6=slower-better).
   optional int32 method = 9 [default =  4];
 
+  // Maximum PSNR change used in slope optimization.
   optional float slope_dpsnr = 10 [default = 1.0];
 }

--- a/src/thumbnailer.proto
+++ b/src/thumbnailer.proto
@@ -32,4 +32,9 @@ message ThumbnailerOption {
 
   // If true, thumbnailer will print various encoding statistics.
   optional bool verbose = 8 [default = false];
+
+  // effort/speed trade-off (0=fast, 6=slower-better)
+  optional int32 method = 9 [default =  4];
+
+  optional float slope_dpsnr = 10 [default = 1.0];
 }

--- a/src/thumbnailer_slope_optim.cc
+++ b/src/thumbnailer_slope_optim.cc
@@ -18,12 +18,6 @@ namespace libwebp {
 
 Thumbnailer::Status Thumbnailer::GenerateAnimationSlopeOptim(
     WebPData* const webp_data) {
-  for (auto& frame : frames_) {
-    // Initialize 'lossy_data' array.
-    std::fill(frame.lossy_data, frame.lossy_data + 101,
-              std::make_pair(-1, -1.0));
-  }
-
   CHECK_THUMBNAILER_STATUS(LossyEncodeSlopeOptim(webp_data));
   CHECK_THUMBNAILER_STATUS(NearLosslessEqual(webp_data));
 
@@ -64,7 +58,7 @@ Thumbnailer::Status Thumbnailer::FindMedianSlope(float* const median_slope) {
 
       CHECK_THUMBNAILER_STATUS(GetPictureStats(curr_ind, &new_size, &new_psnr));
 
-      if (psnr_100 - new_psnr <= 1.0) {
+      if (psnr_100 - new_psnr <= slope_dPSNR_) {
         pic_final_slope = (psnr_100 - new_psnr) / float(size_100 - new_size);
         max_quality = mid_quality - 1;
       } else {


### PR DESCRIPTION
I want to add more options to thumbnailer and copy `examples/example_util.cc` and `examples/example_util.h` from libwebp in order to use utility function parsing intergers and floats in `main.cc`.
 
However, there was an error when I compiled the code:
```
FAILED: thumbnailer
: && /usr/bin/c++    -rdynamic CMakeFiles/thumbnailer.dir/src/main.cc.o  -o thumbnailer  libthumbnailer_lib.a  libimagedec.a  /usr/lib/x86_64-linux-gnu/libprotobuf.so  -lpthread  libimageio_util.a  libexample_util.a  -lwebpmux  -lwebpdemux  -lwebp  /usr/lib/x86_64-linux-gnu/libpng.so  /usr/lib/x86_64-linux-gnu/libz.so  /usr/lib/x86_64-linux-gnu/libjpeg.so  /usr/lib/x86_64-linux-gnu/libtiff.so && :
/usr/bin/ld: libexample_util.a(example_util.c.o): in function `ExUtilInitCommandLineArguments':
example_util.c:(.text+0x45f): undefined reference to `WebPMalloc'
collect2: error: ld returned 1 exit status
```
Also, I added `example_util.c` target to CMake file but the error still exists. I don't know how to resolve this issue.

**Edit : Issue resolved.**