### PR TITLE
Fix PSNR issue for near-lossless & Speed-up thumbnail generation.

### DIFF
--- a/src/thumbnailer.h
+++ b/src/thumbnailer.h
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <cassert>
 #include <memory>
-#include <queue>
 #include <utility>
 #include <vector>
 

--- a/src/thumbnailer.h
+++ b/src/thumbnailer.h
@@ -29,6 +29,7 @@
 
 #include "../imageio/image_dec.h"
 #include "../imageio/imageio_util.h"
+#include "../imageio/webpdec.h"
 #include "thumbnailer.pb.h"
 #include "webp/encode.h"
 #include "webp/mux.h"

--- a/src/thumbnailer_near_lossless.cc
+++ b/src/thumbnailer_near_lossless.cc
@@ -19,7 +19,7 @@ namespace libwebp {
 // speed-up the algorithm. It is not necessary to binary search for all the
 // values in range [0,100] since actually for near-lossless, the frame size and
 // PSNR are not changed when the preprocessing increases a small quantity.
-const int kPreprocessingList[6] = {0, 20, 40, 60, 80, 100};
+static const int kPreprocessingList[6] = {0, 20, 40, 60, 80, 100};
 
 Thumbnailer::Status Thumbnailer::NearLosslessDiff(WebPData* const webp_data) {
   int anim_size = GetAnimationSize(webp_data);

--- a/src/thumbnailer_slope_optim.cc
+++ b/src/thumbnailer_slope_optim.cc
@@ -21,7 +21,7 @@ Thumbnailer::Status Thumbnailer::GenerateAnimationSlopeOptim(
   CHECK_THUMBNAILER_STATUS(LossyEncodeSlopeOptim(webp_data));
   CHECK_THUMBNAILER_STATUS(NearLosslessEqual(webp_data));
 
-  // If all frames are encoded with near-lossless, lossy encode extra step will
+  // If all frames are encoded with near-lossless, lossy extra steps will
   // not be called.
   bool all_frame_near_lossless = true;
   for (int i = 0; i < frames_.size(); ++i) {

--- a/src/thumbnailer_slope_optim.cc
+++ b/src/thumbnailer_slope_optim.cc
@@ -21,6 +21,14 @@ Thumbnailer::Status Thumbnailer::GenerateAnimationSlopeOptim(
   CHECK_THUMBNAILER_STATUS(LossyEncodeSlopeOptim(webp_data));
   CHECK_THUMBNAILER_STATUS(NearLosslessEqual(webp_data));
 
+  // If all frames are encoded with near-lossless, lossy encode extra step will
+  // not be called.
+  bool all_frame_near_lossless = true;
+  for (int i = 0; i < frames_.size(); ++i) {
+    all_frame_near_lossless &= frames_[i].near_lossless;
+  }
+  if (all_frame_near_lossless) return kOk;
+
   int curr_anim_size = webp_data->size;
   const int KMaxIter = 5;
   for (int i = 0; i < KMaxIter; ++i) {


### PR DESCRIPTION
- Compute the correct distortion for near-lossless by decoding the encoded bitstream.
- Speed-up the `NearLosslessEqual()` and `NearLosslessDiff()` by reducing the binary search range.